### PR TITLE
Convert 12:MM AM import start/end times to 00:MM AM

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: smartabaseR
 Title: R Wrapper for the Smartabase API
-Version: 0.0.12
+Version: 0.0.13
 Authors@R: c(
     person("Zac", "Pross", , "zpross@teamworks.com", role = c("aut", "cre")),
     person("James", "Day", , "jday@teamworks.com", role = "aut"),

--- a/R/import_clean.R
+++ b/R/import_clean.R
@@ -281,6 +281,21 @@
 }
 
 
+#' .convert_12am_time
+#'
+#' Converts 12 AM start/end times to 00 AM start times
+#' @noRd
+#' @keywords internal
+.convert_12am_time <- function(df) {
+  df %>%
+    dplyr::mutate(
+      dplyr::across(
+        dplyr::all_of(c("start_time", "end_time")),
+        ~ stringr::str_replace(., "^12:(\\d{2}) (?i)am$", "00:\\1 AM")
+      )
+    )
+}
+
 
 #' .prepare_import_df
 #'

--- a/R/import_handler.R
+++ b/R/import_handler.R
@@ -42,6 +42,7 @@
   df <- df %>%
     dplyr::ungroup() %>%
     .insert_date_time(., arg$current_env) %>%
+    .convert_12am_time(.) %>%
     .attach_user_id_to_df(., arg)
 
   arg$duplicate_date_user_id <- .detect_duplicate_date_user_id(df, arg)

--- a/smartabaseR.Rproj
+++ b/smartabaseR.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 701ce363-77d9-4969-8453-6e2a46deb53b
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/tests/testthat/test-helpers_insert_date_time.R
+++ b/tests/testthat/test-helpers_insert_date_time.R
@@ -281,3 +281,24 @@ test_that("Check .insert_date_time() works", {
     )
   )
 })
+
+
+test_that("Check .convert_12am_time() converts 12 AM to 00 AM", {
+  df <- tibble::tibble(
+    start_time = "12:00 AM",
+    end_time = "12:30 AM"
+  ) %>%
+    .convert_12am_time(.)
+
+  expect_equal(df$start_time[[1]], "00:00 AM")
+  expect_equal(df$end_time[[1]], "00:30 AM")
+
+  df <- tibble::tibble(
+    start_time = "12:00 PM",
+    end_time = "12:30 PM"
+  ) %>%
+    .convert_12am_time(.)
+
+  expect_equal(df$start_time[[1]], "12:00 PM")
+  expect_equal(df$end_time[[1]], "12:30 PM")
+})


### PR DESCRIPTION
When an event has a start/end time of 12:MM AM, it will read as 12:MM AM upon export. However, when importing, AMS requires 12:MM AM times to actually read as 00:MM AM. This pull request adds a helper function .convert_12am_time() that conditionally mutates any start/end times in the import df from 12:MM AM to 00:MM AM