### PR TITLE
tidyjson dependancy issue

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           extra-packages: |
             any::rcmdcheck
-            any:tidyjson
+            any::tidyjson
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -43,7 +43,6 @@ jobs:
         with:
           extra-packages: |
             any::rcmdcheck
-            any::tidyjson
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,7 +41,9 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: |
+            any::rcmdcheck
+            any:tidyjson
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           extra-packages: |
             any::pkgdown,
-            any:tidyjson,
+            any::tidyjson,
             local::.
           needs: website
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -32,7 +32,10 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::.
+          extra-packages: |
+            any::pkgdown,
+            any:tidyjson,
+            local::.
           needs: website
 
       - name: Build site

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -34,7 +34,6 @@ jobs:
         with:
           extra-packages: |
             any::pkgdown,
-            any::tidyjson,
             local::.
           needs: website
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ inst/doc
 Meta
 doc
 .Rproj.user
+.Rproj
 .Rhistory
 .RData
 .Ruserdata

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     tidyselect,
     usethis
 Remotes:
-  colearendt/tidyson#150
+  shikokuchuo/tidyjson@purrr-fix
 Suggests: 
     ggplot2,
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: smartabaseR
 Title: R Wrapper for the Smartabase API
-Version: 0.1.0
+Version: 0.2.0
 Authors@R: c(
     person("Zac", "Pross", , "zpross@teamworks.com", role = c("aut", "cre")),
     person("James", "Day", , "jday@teamworks.com", role = "aut"),
@@ -23,7 +23,7 @@ Imports:
     lubridate,
     magrittr,
     memoise,
-    purrr,
+    purrr (<= 1.1.0),
     readr,
     rlang,
     stringr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     lubridate,
     magrittr,
     memoise,
-    purrr (<= 1.1.0),
+    purrr,
     readr,
     rlang,
     stringr,
@@ -32,6 +32,8 @@ Imports:
     tidyr,
     tidyselect,
     usethis
+Remotes:
+  hikokuchuo/tidyjson
 Suggests: 
     ggplot2,
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     tidyselect,
     usethis
 Remotes:
-  hikokuchuo/tidyjson
+  colearendt/tidyson#150
 Suggests: 
     ggplot2,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
-# smartabaseR 0.0.10
+# smartabaseR 0.2.0
 
-* Initial CRAN submission.
+* Fixed the `purrr` version to 1.1.0 temporarily, as `tidyjson` is failing with newer versions
+
+
+# smartabaseR 0.1.0
+
+* Initial release

--- a/smartabaseR.Rproj
+++ b/smartabaseR.Rproj
@@ -3,7 +3,7 @@ ProjectId: 701ce363-77d9-4969-8453-6e2a46deb53b
 
 RestoreWorkspace: No
 SaveWorkspace: No
-AlwaysSaveHistory: Default
+AlwaysSaveHistory: No
 
 EnableCodeIndexing: Yes
 UseSpacesForTab: Yes


### PR DESCRIPTION
There is an ongoing issue with the `tidyjson` package that hasn't been updated in 2 weeks. It uses a deprecated function from `purrr`. 

Ideally the maintainer will update the `tidyjson` package but in the interim, we have to fix the `purrr` version.

This PR simply updates the dependancy list in DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 0.2.0
  * Added a remote dependency (tidyjson) and pinned purrr to 1.1.0 for compatibility
  * Added a new author entry ("Teamworks")
  * Updated IDE project settings and ignore pattern; adjusted CI workflow inputs formatting

* **Documentation**
  * Updated NEWS to introduce 0.2.0 and note the compatibility fix
<!-- end of auto-generated comment: release notes by coderabbit.ai -->