### PR TITLE
Fix mixed column type error when combining paginated pages (DP-1547)

### DIFF
--- a/R/export_handler.R
+++ b/R/export_handler.R
@@ -210,6 +210,15 @@
       dplyr::select(-dplyr::any_of(c("start_time", "end_time"))) %>%
       readr::type_convert(col_types = readr::cols()) %>%
       dplyr::bind_cols(time_cols)
+  } else {
+    # Even when guess_col_type is FALSE, the metadata ID columns must always be
+    # numeric. The character coercion above (needed for safe bind_rows) would
+    # otherwise leave them as character, violating the documented output contract.
+    id_cols <- c("user_id", "entered_by_user_id", "event_id")
+    combined <- dplyr::mutate(
+      combined,
+      dplyr::across(dplyr::any_of(id_cols), as.numeric)
+    )
   }
 
   class_type <- if (isTRUE(arg$option$interactive_mode)) {

--- a/R/export_handler.R
+++ b/R/export_handler.R
@@ -192,7 +192,25 @@
 #' @keywords internal
 .combine_paginated_pages <- function(pages, arg) {
   last_page <- pages[[length(pages)]]
-  combined  <- dplyr::bind_rows(purrr::map(pages, tibble::as_tibble))
+
+  # Coerce every column to character before binding so that type mismatches
+  # across pages (e.g. a field that is numeric on page 1 but an empty string
+  # on page 18) don't cause bind_rows() to error. Type inference is then
+  # re-applied on the full combined dataset below.
+  combined <- dplyr::bind_rows(
+    purrr::map(pages, ~ dplyr::mutate(
+      tibble::as_tibble(.x),
+      dplyr::across(dplyr::everything(), as.character)
+    ))
+  )
+
+  if (isTRUE(arg$option$guess_col_type)) {
+    time_cols <- dplyr::select(combined, dplyr::any_of(c("start_time", "end_time")))
+    combined  <- combined %>%
+      dplyr::select(-dplyr::any_of(c("start_time", "end_time"))) %>%
+      readr::type_convert(col_types = readr::cols()) %>%
+      dplyr::bind_cols(time_cols)
+  }
 
   class_type <- if (isTRUE(arg$option$interactive_mode)) {
     "sb_df"

--- a/tests/testthat/test-export_handler.R
+++ b/tests/testthat/test-export_handler.R
@@ -50,6 +50,73 @@ test_that("{page_n} interpolates in paginate_export progress message without err
   expect_match(as.character(rendered), "Test Form",        fixed = TRUE)
 })
 
+
+# Helper: build a minimal sb_df page with a typed Post Code column
+make_mock_page <- function(post_code_vec) {
+  df <- tibble::tibble(
+    about        = paste("Athlete", seq_along(post_code_vec)),
+    user_id      = as.integer(seq_along(post_code_vec)),
+    `Post Code`  = post_code_vec
+  )
+  result <- tibble::new_tibble(
+    df,
+    nrow             = nrow(df),
+    class            = "sb_df_non_interactive",
+    request          = list(),
+    http_method      = "POST",
+    http_status_code = 200L
+  )
+  attr(result, "form")        <- "Test Form"
+  attr(result, "export_time") <- as.POSIXct("2025-01-01")
+  result
+}
+
+test_that(".combine_paginated_pages() handles double/character type conflict (DP-1547)", {
+  # Reproduce the exact error: pages where per-page type_convert gives
+  # <double> on numeric-only pages and <character> on blank-only pages.
+  page_double <- make_mock_page(c(2000, 3000, 4000))   # already numeric
+  page_char   <- make_mock_page(c("", "", ""))          # character, type_convert left as-is
+
+  # Confirm the old bare bind_rows would error with this input
+  expect_error(
+    dplyr::bind_rows(purrr::map(list(page_double, page_char), tibble::as_tibble)),
+    regexp = "Can't combine"
+  )
+
+  arg <- list(
+    form     = "Test Form",
+    endpoint = "eventsearch",
+    option   = list(interactive_mode = FALSE, guess_col_type = TRUE)
+  )
+
+  result <- .combine_paginated_pages(list(page_double, page_char), arg)
+
+  expect_s3_class(result, "data.frame")
+  expect_equal(nrow(result), 6L)
+  expect_type(result$`Post Code`, "double")
+  # Blank-page rows become NA, not errors
+  expect_equal(sum(is.na(result$`Post Code`)), 3L)
+  expect_equal(result$`Post Code`[1:3], c(2000, 3000, 4000))
+})
+
+test_that(".combine_paginated_pages() with guess_col_type = FALSE still succeeds", {
+  page_double <- make_mock_page(c(2000, 3000))
+  page_char   <- make_mock_page(c("", ""))
+
+  arg <- list(
+    form     = "Test Form",
+    endpoint = "eventsearch",
+    option   = list(interactive_mode = FALSE, guess_col_type = FALSE)
+  )
+
+  result <- .combine_paginated_pages(list(page_double, page_char), arg)
+
+  expect_s3_class(result, "data.frame")
+  expect_equal(nrow(result), 4L)
+  # Without re-typing, column stays character (coerced from double then not re-converted)
+  expect_type(result$`Post Code`, "character")
+})
+
 test_that("{page_n} interpolation fails with wrong env, confirming the regression was real", {
   # Mirror the broken code path (.envir = arg$current_env where page_n is absent)
   # to confirm that using the wrong environment does indeed error. This ensures

--- a/tests/testthat/test-export_handler.R
+++ b/tests/testthat/test-export_handler.R
@@ -99,7 +99,7 @@ test_that(".combine_paginated_pages() handles double/character type conflict (DP
   expect_equal(result$`Post Code`[1:3], c(2000, 3000, 4000))
 })
 
-test_that(".combine_paginated_pages() with guess_col_type = FALSE still succeeds", {
+test_that(".combine_paginated_pages() with guess_col_type = FALSE keeps metadata ID cols numeric", {
   page_double <- make_mock_page(c(2000, 3000))
   page_char   <- make_mock_page(c("", ""))
 
@@ -113,8 +113,10 @@ test_that(".combine_paginated_pages() with guess_col_type = FALSE still succeeds
 
   expect_s3_class(result, "data.frame")
   expect_equal(nrow(result), 4L)
-  # Without re-typing, column stays character (coerced from double then not re-converted)
+  # User form fields stay as character when guess_col_type is FALSE
   expect_type(result$`Post Code`, "character")
+  # Metadata ID columns must always be numeric regardless of guess_col_type
+  expect_type(result$user_id, "double")
 })
 
 test_that("{page_n} interpolation fails with wrong env, confirming the regression was real", {


### PR DESCRIPTION
## Summary

- **Bug:** When paginating a large export, \`readr::type_convert()\` runs independently on each page. If a field (e.g. *Post Code*) is numeric on some pages but blank on others, per-page type inference produces \`<double>\` on numeric pages and \`<character>\` on blank pages — \`dplyr::bind_rows()\` then throws \`Can't combine \`..1$Post Code\` <double> and \`..18$Post Code\` <character>\`.
- **Fix:** In \`.combine_paginated_pages()\`, coerce all page columns to character before \`bind_rows()\`, then re-run \`readr::type_convert()\` on the full combined dataset. Types are now inferred from all values at once rather than page-by-page, and blank values correctly become \`NA\` rather than causing a type conflict.
- **Tests:** Two new regression tests — one reproduces the exact \`Can't combine\` error with the old code path, one verifies the fix with correct output types. The \`guess_col_type = FALSE\` path is also covered.

## Relates to

DP-1547 (NSWIS — mixed column types when combining paginated pages)

## Test plan

- [x] \`devtools::test()\` passes (15/15 in \`test-export_handler.R\`)
- [x] Install package and run \`sb_get_event()\` against a form with blank fields across page boundaries
- [x] Verify blank field values appear as \`NA\` in the returned tibble rather than erroring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed paginated exports failing when pages had mismatched column types by applying safer, per-page binding and consistent type alignment.
  * When type detection is enabled, time columns are preserved during conversion and restored afterward; when disabled, only identifier metadata columns are coerced to numeric while other columns keep their expected formats.

* **Tests**
  * Added regression coverage for mixed-type “Post Code” inputs and for behavior with type detection both enabled and disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->